### PR TITLE
Create create_merchant method; needs refactor

### DIFF
--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -7,7 +7,4 @@ class MerchantRepository
     # turn parsed data into Ruby objects
   end
 
-  def create_merchants
-  end
-
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -28,7 +28,14 @@ class SalesEngine
   end
 
   def merchants
-    MerchantRepository.new(parse_csv(@merchants))
+    MerchantRepository.new(create_merchants(parse_csv(@merchants)))
+  end
+
+  def create_merchants(parsed_data)
+     test = parsed_data.map do |merchant|
+      Merchant.new(merchant)
+    end
+     require 'pry'; binding.pry
   end
 
   def items

--- a/spec/sales_engine_spec.rb
+++ b/spec/sales_engine_spec.rb
@@ -1,5 +1,7 @@
 require_relative '../lib/sales_engine'
-
+require_relative '../lib/merchant'
+require_relative '../lib/item_repository'
+require_relative '../lib/merchant_repository'
 
 RSpec.describe SalesEngine do
   describe '#initialization' do
@@ -40,6 +42,11 @@ RSpec.describe SalesEngine do
 
     it 'returns an object of class ItemRepository' do
       expect(sales_engine.items).to be_an_instance_of(ItemRepository)
+    end
+
+    it 'can create merchant objects' do
+      merchant_data = SalesEngine.parse_csv("./data/merchants.csv")
+      expect(sales_engine.create_merchants(merchant_data)[0]).to be_instance_of(Merchant)
     end
   end
 end


### PR DESCRIPTION
Functionality for creating Merchant  instances is complete. Refactor is needed to move it under `MerchantRepository` instead of `SalesEngine`