### PR TITLE
Parse refactor

### DIFF
--- a/lib/item_repository.rb
+++ b/lib/item_repository.rb
@@ -1,18 +1,23 @@
 require_relative '../lib/sales_engine'
 require_relative '../lib/item'
+require_relative 'parsable'
 require 'bigdecimal/util'
 
-class ItemRepository
 
-  def initialize(parsed_data)
-    create_items(parsed_data)
+class ItemRepository
+  include Parsable
+
+  def initialize(data)
+    create_items(data)
   end
+
   #add so spec harness would run successfully.
   def inspect
   "#<#{self.class} #{@items_array.size} rows>"
   end
 
-  def create_items(parsed_data)
+  def create_items(item_data)
+    parsed_data = parse_csv(item_data)
     @items_array = parsed_data.map do |item|
       Item.new(item)
    end

--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -1,16 +1,21 @@
 require_relative '../lib/merchant'
+require_relative 'parsable'
 
 class MerchantRepository
+  include Parsable
   attr_reader :merchants
-  def initialize(parsed_csv)
-    @merchants = create_merchants(parsed_csv)
+
+  def initialize(data)
+    @merchants = create_merchants(data)
   end
+
   #add so spec harness would run successfully.
   def inspect
   "#<#{self.class} #{@merchants.size} rows>"
   end
 
-  def create_merchants(parsed_data)
+  def create_merchants(merchant_data)
+    parsed_data = parse_csv(merchant_data)
      parsed_data.map do |merchant|
       Merchant.new(merchant)
     end

--- a/lib/parsable.rb
+++ b/lib/parsable.rb
@@ -1,0 +1,21 @@
+require 'CSV'
+
+module Parsable
+
+  def parse_csv(path)
+    parsed_csv = CSV.parse(File.read(path), headers: true, header_converters: :symbol).to_a
+    headers = parsed_csv.shift
+    repo = []
+    parsed_csv.each do |data|
+      new_hash = Hash.new
+      counter = 0
+      headers.each do |header|
+        new_hash[header] = data[counter]
+        counter += 1
+      end
+      repo << new_hash
+    end
+    repo
+  end
+
+end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -1,4 +1,3 @@
-require 'CSV'
 require_relative '../lib/merchant_repository'
 require_relative '../lib/item_repository'
 
@@ -13,68 +12,11 @@ class SalesEngine
      SalesEngine.new(csv_data)
   end
 
-  def self.parse_csv(path)
-    parsed_csv = CSV.parse(File.read(path), headers: true, header_converters: :symbol).to_a
-    headers = parsed_csv.shift
-    repo = []
-    parsed_csv.each do |data|
-      new_hash = Hash.new
-      counter = 0
-      headers.each do |header|
-        new_hash[header] = data[counter]
-        counter += 1
-      end
-      repo << new_hash
-    end
-    repo
-  end
-
   def merchants
-    MerchantRepository.new(SalesEngine.parse_csv(@merchants))
+    MerchantRepository.new(@merchants)
   end
 
   def items
-    ItemRepository.new(SalesEngine.parse_csv(@items))
+    ItemRepository.new(@items)
   end
 end
-
-
-
-
-
-
-#
-# needs to intake the files and then make them usable by both merchant repo and item repo. intake files from_csv method.
-#
-# items method will return an instance of item repository. item repository will have all of the items in it.
-#
-# merchant method will return an instance of merchant repository. merchant repository gets created with all of the merchant objects
-
-
-
-# Leigh's group project
-# class StatTracker
-#   attr_reader :games_data,
-#               :team_data,
-#               :game_teams_data,
-#               :game_manager,
-#               :game_team_manager,
-#               :team_manager
-#
-#   def initialize(locations)
-#     load_manager(locations)
-#   end
-#
-#   def self.from_csv(locations)
-#     StatTracker.new(locations)
-#   end
-#
-#   def load_manager(locations)
-#    @team_manager = TeamManager.new(load_csv(locations[:teams]), self)
-#    @game_manager = GameManager.new(load_csv(locations[:games]), self)
-#    @game_team_manager = GameTeamsManager.new(load_csv(locations[:game_teams]), self)
-#   end
-#
-#   def load_csv(path)
-#     CSV.parse(File.read(path), headers: true, header_converters: :symbol)
-#   end

--- a/spec/item_repository_spec.rb
+++ b/spec/item_repository_spec.rb
@@ -1,10 +1,12 @@
 require_relative '../lib/sales_engine'
 require_relative '../lib/item_repository'
 require_relative '../lib/item'
+require_relative '../lib/parsable'
 require 'bigdecimal/util'
 
 RSpec.describe ItemRepository do
   describe 'initialization' do
+    include Parsable
     sales_engine = SalesEngine.from_csv({
                               :items     => "./data/items.csv",
                               :merchants => "./data/merchants.csv",
@@ -16,8 +18,7 @@ RSpec.describe ItemRepository do
     end
 
     it 'can create item objects' do
-      item_data = SalesEngine.parse_csv("./data/items.csv")
-      expect(repo.create_items(item_data)[0]).to be_instance_of(Item)
+      expect(repo.create_items("./data/items.csv")[0]).to be_instance_of(Item)
     end
   end
 

--- a/spec/merchant_repository_spec.rb
+++ b/spec/merchant_repository_spec.rb
@@ -1,12 +1,12 @@
 require_relative '../lib/sales_engine'
 require_relative '../lib/merchant'
 require_relative '../lib/merchant_repository'
+require_relative '../lib/parsable'
 
 RSpec.describe MerchantRepository do
 
-  # Parameter (array of hashes) should be passed
-  # into new instance
   describe 'initialization' do
+    include Parsable
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./data/items.csv",
                                         :merchants => "./data/merchants.csv",
@@ -22,8 +22,7 @@ RSpec.describe MerchantRepository do
     end
 
     it 'can create merchant objects' do
-      merchant_data = SalesEngine.parse_csv("./data/merchants.csv")
-      expect(merch_rep.create_merchants(merchant_data)[0]).to be_instance_of(Merchant)
+      expect(merch_rep.create_merchants("./data/merchants.csv")[0]).to be_instance_of(Merchant)
     end
   end
 

--- a/spec/parsable_spec.rb
+++ b/spec/parsable_spec.rb
@@ -1,0 +1,18 @@
+require_relative '../lib/parsable'
+
+RSpec.describe Parsable do
+  include Parsable
+
+  it 'parse csv merchants' do
+    expect(parse_csv("./data/merchants.csv")).to be_instance_of(Array)
+  end
+
+  it 'parse csv items' do
+    expect(parse_csv("./data/items.csv")).to be_instance_of(Array)
+  end
+
+  it 'creates hashes' do
+    expect(parse_csv("./data/merchants.csv")[0]).to be_instance_of(Hash)
+  end
+
+end

--- a/spec/sales_engine_spec.rb
+++ b/spec/sales_engine_spec.rb
@@ -16,17 +16,6 @@ RSpec.describe SalesEngine do
       expect(sales_engine.merchants).to eq("./data/merchants.csv")
     end
 
-    it 'parse csv merchants' do
-      expect(SalesEngine.parse_csv("./data/merchants.csv")).to be_instance_of(Array)
-    end
-
-    it 'parse csv items' do
-      expect(SalesEngine.parse_csv("./data/items.csv")).to be_instance_of(Array)
-    end
-
-    it 'creates hashes' do
-      expect(SalesEngine.parse_csv("./data/merchants.csv")[0]).to be_instance_of(Hash)
-    end
   end
 
   describe '#items & #merchants' do


### PR DESCRIPTION
The PR implements a Parsable module so we can reuse the `parse_csv` method across all of the repositories we make. This refactor also takes the responsibility out of the hands of `SalesEngine`. All RSpec tests pass and passing Parsable tests were introduced.