### PR TITLE
Verified average items per merchant and standard deviation methods

### DIFF
--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -18,6 +18,7 @@ class SalesAnalyst
     merchants.map do |merchant|
       merchant.id
     end
+  end
 
   def average_items_per_merchant(merchants)
     merchant_ids = get_merchant_ids(merchants)
@@ -25,18 +26,15 @@ class SalesAnalyst
     merchant_ids.each do |merchant_id|
       if find_all_by_merchant_id.include?(merchant_id)
         item_counter += 1
+        require 'pry'; binding.pry
       end
     end
-    #average_items_per_merchant (array of merchant ids)
-    #iterate through array of merchant ids
-    #item counter = 0
     #for each id, compare against merchant ids in items
     #each time id is matched, add += 1 to counter
 
     # counter / merchants.length.to_f
 
-    avg = find_all_items.length / merchants.length.to_f
-    avg.truncate(2)
+    #avg.truncate(2)
   end
 
   def sample_merchants_return_id
@@ -53,8 +51,7 @@ class SalesAnalyst
     sample_size_minus_one = merchant_items.length - 1
     counter = 0
     merchant_items.each do |number|
-      running_total = (number - average_items_per_merchant)
-require 'pry'; binding.pry
+      running_total = (number)**2 # add in average subtracted here
       counter += running_total
     end
     Math.sqrt(counter / sample_size_minus_one)

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -20,21 +20,14 @@ class SalesAnalyst
     end
   end
 
-  def average_items_per_merchant(merchants)
-    merchant_ids = get_merchant_ids(merchants)
+  def average_items_per_merchant(merchant_ids)
     item_counter = 0
     merchant_ids.each do |merchant_id|
-      if find_all_by_merchant_id.include?(merchant_id)
-        item_counter += 1
-        require 'pry'; binding.pry
-      end
+      item_counter += find_all_items_by_merchant_id(merchant_id).length
     end
-    #for each id, compare against merchant ids in items
-    #each time id is matched, add += 1 to counter
 
-    # counter / merchants.length.to_f
-
-    #avg.truncate(2)
+    average = item_counter / merchant_ids.length.to_f
+    average.truncate(2)
   end
 
   def sample_merchants_return_id
@@ -45,27 +38,21 @@ class SalesAnalyst
   def stnd_dev_of_merch_items
     merchant_items = []
     sample_merchants_return_id.each do |merchant_id|
-      merchant_items << find_all_by_merchant_id(merchant_id).length
+      merchant_items << find_all_items_by_merchant_id(merchant_id).length
     end
-
     sample_size_minus_one = merchant_items.length - 1
     counter = 0
     merchant_items.each do |number|
-      running_total = (number)**2 # add in average subtracted here
+      running_total = (number - average_items_per_merchant(sample_merchants_return_id))**2 
       counter += running_total
     end
     Math.sqrt(counter / sample_size_minus_one)
-
   end
 
-  def find_all_by_merchant_id(merchant_id)
+  def find_all_items_by_merchant_id(merchant_id)
     find_all_items.find_all do |item|
       item.merchant_id == merchant_id
     end
   end
-    # sqrt (((std_dev_arry[0]-average_items_per_merchant)**2)+
-    #         (std_dev_arry[1]-average_items_per_merchant)**2)+
-    #         (std_dev_arry[2, et cetera]-average_items_per_merchant)**2)
-    #       /2)
-end
+
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe do
     end
 
     it 'calculates average_items_per_merchant' do
-      #Need to decide how to test this. Stub? Fixture data set?
-      first_ten_merchants = sales_engine.merchants.array_of_objects[0..9]
-      expect(sales_analyst.average_items_per_merchant(first_ten_merchants)).to eq(4.4)
+      # Average of 2.5 was verified by searching fixture file with first 10 ID's
+      expected_array = [12334105,12334112,12334113,12334115,12334123,12334132,12334135,12334141,12334144,12334145]
+      expect(sales_analyst.average_items_per_merchant(expected_array)).to eq(2.5)
     end
 
     it 'returns set of ten merchant ids' do
@@ -42,14 +42,12 @@ RSpec.describe do
 
     it 'returns standard deviation of merchant item count' do
       expected_array = [12334105,12334112,12334113,12334115,12334123,12334132,12334135,12334141,12334144,12334145]
-      allow(sales_analyst.stnd_dev_of_merch_items).to receive(:sample_merchants_return_id) do
-        expected_array
+      first_ten_merchants = sales_engine.merchants.array_of_objects[0..9]
+      allow(sales_analyst.find_all_merchants).to receive(:sample) do
+        first_ten_merchants
       end
-      # expected =   sqrt (((std_dev_arry[0]-average_items_per_merchant)**2)+
-      #            (std_dev_arry[1]-average_items_per_merchant)**2)+
-      #            (std_dev_arry[2, et cetera]-average_items_per_merchant)**2)
-      #          /2)
-      expect(sales_analyst.stnd_dev_of_merch_items).to eq(7.486283754)
+
+      expect(sales_analyst.stnd_dev_of_merch_items).to be_between(5.1, 5.3)
     end
   end
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe do
 
     it 'calculates average_items_per_merchant' do
       #Need to decide how to test this. Stub? Fixture data set?
-      expect(sales_analyst.average_items_per_merchant(sales_engine.merchants.array_of_objects)).to be_an_instance_of(Float)
+      first_ten_merchants = sales_engine.merchants.array_of_objects[0..9]
+      expect(sales_analyst.average_items_per_merchant(first_ten_merchants)).to eq(4.4)
     end
 
     it 'returns set of ten merchant ids' do


### PR DESCRIPTION
This PR implements a verified testing framework to calculate average number of items per merchant, which in turn the standard deviation method was dependent on.