### PR TITLE
SalesAnalyst refactor of instance variables

### DIFF
--- a/lib/compute.rb
+++ b/lib/compute.rb
@@ -1,7 +1,11 @@
 class Compute
 
   def self.mean(sum, num_of_elements)
-    mean = sum.to_f / num_of_elements
+    if sum.class == BigDecimal
+      mean = sum / num_of_elements
+    else
+      mean = sum.to_f / num_of_elements
+    end
     mean.round(2)
   end
 

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -3,15 +3,18 @@ require 'date'
 
 class SalesAnalyst
 
-  attr_reader :engine
+  attr_reader :engine, :merchants, :items, :invoices
 
   def initialize(engine)
     @engine = engine
+    @merchants = engine.merchants.array_of_objects
+    @items = engine.merchants.array_of_objects
+    @invoices = engine.invoices.array_of_objects
   end
 
-  def find_all_merchants
-    @engine.merchants.array_of_objects
-  end
+  # def find_all_merchants
+  #   @engine.merchants.array_of_objects
+  # end
 
   def find_all_items
     @engine.items.array_of_objects
@@ -30,7 +33,7 @@ class SalesAnalyst
   end
 
   def items_per_merchant
-    find_all_merchants.map do |merchant|
+    merchants.map do |merchant|
       find_all_items_by_merchant_id(merchant.id).length
     end
   end
@@ -49,7 +52,7 @@ class SalesAnalyst
   def merchants_with_high_item_count
     mean = average_items_per_merchant
     greater_than_1sd = mean + average_items_per_merchant_standard_deviation
-    find_all_merchants.find_all do |merchant|
+    merchants.find_all do |merchant|
       find_all_items_by_merchant_id(merchant.id).length > greater_than_1sd
     end
   end
@@ -67,10 +70,10 @@ class SalesAnalyst
   end
 
   def average_average_price_per_merchant
-    items_sum = find_all_merchants.sum do |merchant|
+    items_sum = merchants.sum do |merchant|
       average_item_price_for_merchant(merchant.id)
     end
-    Compute.mean(items_sum, find_all_merchants.length)
+    Compute.mean(items_sum, merchants.length)
   end
 
   def total_item_price
@@ -117,7 +120,7 @@ class SalesAnalyst
   end
 
   def invoices_per_merchant
-    find_all_merchants.map do |merchant|
+    @merchants.map do |merchant|
       find_all_invoices_by_merchant_id(merchant.id).length
     end
   end
@@ -139,7 +142,7 @@ class SalesAnalyst
   # def merchants_with_high_item_count
   #   mean = average_items_per_merchant
   #   greater_than_1sd = mean + average_items_per_merchant_standard_deviation
-  #   find_all_merchants.find_all do |merchant|
+  #   @merchants.find_all do |merchant|
   #     find_all_items_by_merchant_id(merchant.id).length > greater_than_1sd
   #   end
   # end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -8,16 +8,8 @@ class SalesAnalyst
   def initialize(engine)
     @engine = engine
     @merchants = engine.merchants.array_of_objects
-    @items = engine.merchants.array_of_objects
+    @items = engine.items.array_of_objects
     @invoices = engine.invoices.array_of_objects
-  end
-
-  # def find_all_merchants
-  #   @engine.merchants.array_of_objects
-  # end
-
-  def find_all_items
-    @engine.items.array_of_objects
   end
 
   def get_merchant_ids(merchants)
@@ -27,8 +19,8 @@ class SalesAnalyst
   end
 
   def find_all_items_by_merchant_id(merchant_id)
-    find_all_items.find_all do |item|
-      item.merchant_id == merchant_id
+    items.find_all do |item_object|
+      item_object.merchant_id == merchant_id
     end
   end
 
@@ -59,8 +51,8 @@ class SalesAnalyst
 
   def average_item_price_for_merchant(merchant_id)
     merchant_items = find_all_items_by_merchant_id(merchant_id)
-    sum_of_prices = merchant_items.sum do |item|
-      item.unit_price
+    sum_of_prices = merchant_items.sum do |item_object|
+      item_object.unit_price
     end
     if merchant_items.length != 0
       Compute.mean(sum_of_prices, merchant_items.length)
@@ -77,50 +69,42 @@ class SalesAnalyst
   end
 
   def total_item_price
-    sum = find_all_items.sum do |item_object|
+    items.sum do |item_object|
       item_object.unit_price
     end
   end
 
   def average_price_per_item_standard_deviation
-    total_number_of_items = find_all_items.length
-    mean = Compute.mean(total_item_price, total_number_of_items)
-    adder_counter = find_all_items.sum do |item|
-      (item.unit_price - mean)**2
+    mean = Compute.mean(total_item_price, items.length)
+    adder_counter = items.sum do |item_object|
+      (item_object.unit_price - mean)**2
     end
-    Math.sqrt(adder_counter / (total_number_of_items - 1)).round(2)
+    Math.sqrt(adder_counter / (items.length - 1)).round(2)
   end
 
   def golden_items
-    mean = Compute.mean(total_item_price, find_all_items.length)
+    mean = Compute.mean(total_item_price, items.length)
     two_sd = average_price_per_item_standard_deviation * 2
     greater_than_2sd = mean + two_sd
-    find_all_items.find_all do |item|
-      item.unit_price >= greater_than_2sd
+    items.find_all do |item_object|
+      item_object.unit_price >= greater_than_2sd
     end
   end
 
   ##### INVOICE ITERATION 2 ######
-  def find_all_invoices
-    @engine.invoices.array_of_objects
-  end
-
-  def number_of_all_invoices
-    find_all_invoices.length
-  end
 
   def average_invoices_per_merchant
-    test = Compute.mean(invoices_per_merchant.sum, invoices_per_merchant.length)
+    Compute.mean(invoices_per_merchant.sum, invoices_per_merchant.length)
   end
 
   def find_all_invoices_by_merchant_id(merchant_id)
-    find_all_invoices.find_all do |invoice|
+    invoices.find_all do |invoice|
       invoice.merchant_id == merchant_id
     end
   end
 
   def invoices_per_merchant
-    @merchants.map do |merchant|
+    merchants.map do |merchant|
       find_all_invoices_by_merchant_id(merchant.id).length
     end
   end
@@ -133,9 +117,8 @@ class SalesAnalyst
   end
 
   def top_days_by_invoice_count
-    invoices = find_all_invoices
-    days_array = invoices.map do |invoice|
-      invoice.created_at.strftime('%A')
+    days_array = invoices.map do |invoice_object|
+      invoice_object.created_at.strftime('%A')
     end
   end
 ###THIS IS FOR THE NEXT PART OF ITERATION 2###

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe do
     end
 
     it 'looks up all items' do
-      expect(sales_analyst.find_all_items[1]).to be_an_instance_of(Item)
+      expect(sales_analyst.items[1]).to be_an_instance_of(Item)
     end
 
     it 'calculates average_items_per_merchant' do
@@ -83,7 +83,7 @@ RSpec.describe do
 
     it 'has special golden items for funny reasons' do
       first_20_items = sales_engine.items.array_of_objects[0..19]
-      allow(sales_analyst).to receive(:find_all_items) do
+      allow(sales_analyst).to receive(:items) do
         first_20_items
       end
 

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe do
     end
 
     it 'looks up all merchants' do
-      expect(sales_analyst.find_all_merchants[1]).to be_an_instance_of(Merchant)
+      expect(sales_analyst.merchants[1]).to be_an_instance_of(Merchant)
     end
 
     it 'looks up all items' do
@@ -34,7 +34,7 @@ RSpec.describe do
 
     it 'calculates average_items_per_merchant' do
       first_ten_merchants = sales_engine.merchants.array_of_objects[0..9]
-      allow(sales_analyst).to receive(:find_all_merchants) do
+      allow(sales_analyst).to receive(:merchants) do
         first_ten_merchants
       end
       # Average of 2.5 was verified by searching fixture file with first 10 ID's
@@ -47,7 +47,7 @@ RSpec.describe do
       allow(sales_analyst).to receive(:average_items_per_merchant) do
         2.5
       end
-      allow(sales_analyst).to receive(:find_all_merchants) do
+      allow(sales_analyst).to receive(:merchants) do
         first_ten_merchants
       end
 
@@ -59,7 +59,7 @@ RSpec.describe do
       expected_array = [12334105,12334112,12334113,12334115,12334123,12334132,12334135,12334141,12334144,12334145]
       first_ten_merchants = sales_engine.merchants.array_of_objects[0..9]
       expected_merchant = first_ten_merchants[4]
-      allow(sales_analyst).to receive(:find_all_merchants) do
+      allow(sales_analyst).to receive(:merchants) do
         first_ten_merchants
       end
 
@@ -74,7 +74,7 @@ RSpec.describe do
 
     it 'averages all average prices per merchant' do
       first_ten_merchants = sales_engine.merchants.array_of_objects[0..9]
-      allow(sales_analyst).to receive(:find_all_merchants) do
+      allow(sales_analyst).to receive(:merchants) do
         first_ten_merchants
       end
 


### PR DESCRIPTION
This PR implements instance variables to access merchants, items and invoices in SalesAnalyst instead of having separate getter methods. This change allows greater flexibility to move more of the repeatable math functions out of the SalesAnalyst class.
A bug was also found in the Compute::mean class that overwrote BigDecimal returns into floats, and this was subsequently fixed.