### PR TITLE
Change from .all? to .any? when checking for invoice paid in full

### DIFF
--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -170,7 +170,7 @@ class SalesAnalyst
       transaction.invoice_id == invoice_id
     end
     if all_transactions.length != 0
-      all_transactions.all? do |transaction|
+      all_transactions.any? do |transaction|
         transaction.result == :success
       end
     else

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe do
                                         :transactions => "./data/transactions.csv",
                                         :customers => "./data/customers.csv"
                                         })
-    
+
     sales_analyst = sales_engine.analyst
 
     it '#average_invoices_per_merchant' do
@@ -173,9 +173,7 @@ RSpec.describe do
                                         })
     sales_analyst = sales_engine.analyst
 
-    it '#revenue_by_merchant returns total revenut for a given merchant' do
-      # expect(sales_analyst.revenue_by_merchant(12334634)).to eq(0.19252887e6)
-      # expect(sales_analyst.revenue_by_merchant(12334105)).to eq(106170.51)
+    it '#revenue_by_merchant returns total revenue for a given merchant' do
       expect(sales_analyst.revenue_by_merchant(12334634).class).to eq(BigDecimal)
     end
 


### PR DESCRIPTION
Get  #top_revenue_earners(x) working with and without argument. Passes home grown and spec harness testing. 

The missing key was in the iteration 3 directions that  "An invoice is considered paid in full if it has **a** successful transaction" where as were calculating it only when **all** transactions were successful. So the change was from an all? to an any?  in `sales_analyst.invoice_paid_in_full?`