### PR TITLE
Longest method name ever PR

### DIFF
--- a/lib/merchant.rb
+++ b/lib/merchant.rb
@@ -1,9 +1,11 @@
 class Merchant
   attr_accessor :name,
-                  :id
+                :id,
+                :created_at
 
   def initialize(merchant_info)
     @id = merchant_info[:id].to_i
     @name = merchant_info[:name]
+    @created_at = Time.parse(merchant_info[:created_at])
   end
 end

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -270,55 +270,19 @@ class SalesAnalyst
     tallied_items
   end
 
-  def merchants_by_month_hash
-    months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"]
-    merchants_by_month_hash = Hash.new
-
-      months.each do |month|
-        merchants_by_month_hash[month] = []
-        @merchants.each do |merchant|
-          if does_merchant_have_one_item_in_given_month?(month, merchant.id)
-            merchants_by_month_hash[month].push(merchant.id)
-          end
-        end
-      end
-      merchants_by_month_hash
+  def merchants_with_only_one_item_registered_in_month(month)
+    merchants_selling_only_one_item.find_all do |merchant|
+      merchant.created_at.strftime('%B') == month
+    end
   end
 
-  def does_merchant_have_one_item_in_given_month?(month, merchant_id)
-    merchants_items = find_all_items_by_merchant_id(merchant_id)
-    items_created_in_month = merchants_items.find_all do |item|
-      item.created_at.strftime('%B') == month
-      # require "pry"; binding.pry
-    end
-    if items_created_in_month.length == 1
-      true
-    else
-      false
+  def merchants_selling_only_one_item
+    @merchants.find_all do |merchant|
+      merchants_items = find_all_items_by_merchant_id(merchant.id)
+      merchants_items.length == 1
     end
   end
 end
-
-    # grouped_items = @items.group_by do |item|
-    #   item.created_at.strftime('%B')
-    # end
-    #
-    # merchant_ids_of_items_in_month = grouped_items.transform_values do |value|
-    #   value.map do |item_info|
-    #     item_info.merchant_id
-    #     end
-    #
-    # end
-    # require "pry"; binding.pry
-
-  # def merchants_with_only_one_item_registered_in_month(month)
-  #   merchant_ids_of_items_in_month = grouped_items.transform_values do |value|
-  #     value.map do |item_info|
-  #         item_info.merchant_id
-  #       end
-  #     end
-  # end
-
 
 #find item per merchant in sales engine? or merchant repo gets merchants with their items. (use self?)
 #memoization(sp?) iterating more than we need to means we should trim the iterations as much as possible. The first time we iterate it will

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -8,7 +8,7 @@ require 'bigdecimal/util'
 
 RSpec.describe do
 
-  describe 'initialize' do
+  xdescribe 'initialize' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -91,7 +91,7 @@ RSpec.describe do
     end
   end
 
-  describe 'iteration 2 functionality' do
+  xdescribe 'iteration 2 functionality' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -132,7 +132,7 @@ RSpec.describe do
     end
   end
 
-  describe 'iteration 3 functionality' do
+  xdescribe 'iteration 3 functionality' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -160,7 +160,7 @@ RSpec.describe do
     end
   end
 
-  describe 'AM iteration 4 functionality: revenue_by_merchant + top_revenue_earners' do
+  xdescribe 'AM iteration 4 functionality: revenue_by_merchant + top_revenue_earners' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         # :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -196,7 +196,7 @@ RSpec.describe do
     end
   end
 
-  describe 'iteration 4 functionality' do
+  xdescribe 'iteration 4 functionality' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -237,22 +237,12 @@ RSpec.describe do
       expect(expected.first.class).to eq Merchant
     end
 
-    it "helper method invoices per month" do
-
-      # expect(sales_analyst.merchants_by_month_hash.class).to eq(Hash)
-      expect(sales_analyst.does_merchant_have_one_item_in_given_month?("January", 12334365)).to eq(false)
-    end
-
     it "#merchants_with_only_one_item_registered_in_month returns merchants with only one invoice in given month" do
-      # expected = sales_analyst.merchants_with_only_one_item_registered_in_month("March")
-      expected = sales_analyst.merchants_by_month_hash["March"]
-      expect(expected.length).to eq 21
-      # expect(expected.first.class).to eq Merchant
-
+      march_expected = sales_analyst.merchants_with_only_one_item_registered_in_month("March")
       expected = sales_analyst.merchants_with_only_one_item_registered_in_month("June")
 
+      expect(march_expected.length).to eq 21
       expect(expected.length).to eq 18
-      # expect(expected.first.class).to eq Merchant
     end
   end #keep this for Alex please and thank you
 end

--- a/spec/sales_analyst_spec.rb
+++ b/spec/sales_analyst_spec.rb
@@ -8,7 +8,7 @@ require 'bigdecimal/util'
 
 RSpec.describe do
 
-  xdescribe 'initialize' do
+  describe 'initialize' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -91,7 +91,7 @@ RSpec.describe do
     end
   end
 
-  xdescribe 'iteration 2 functionality' do
+  describe 'iteration 2 functionality' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -132,7 +132,7 @@ RSpec.describe do
     end
   end
 
-  xdescribe 'iteration 3 functionality' do
+  describe 'iteration 3 functionality' do
     sales_engine = SalesEngine.from_csv({
                                         :items     => "./spec/fixtures/items_fixtures.csv",
                                         :merchants => "./spec/fixtures/merchants_fixtures.csv",
@@ -160,9 +160,9 @@ RSpec.describe do
     end
   end
 
-  xdescribe 'AM iteration 4 functionality: revenue_by_merchant + top_revenue_earners' do
+  describe 'AM iteration 4 functionality: revenue_by_merchant + top_revenue_earners' do
     sales_engine = SalesEngine.from_csv({
-                                        :items     => "./spec/fixtures/items_fixtures.csv",
+                                        :items     => "./data/items.csv",
                                         # :merchants => "./spec/fixtures/merchants_fixtures.csv",
                                         :merchants => "./data/merchants.csv",
                                         :invoices => "./data/invoices.csv",
@@ -194,18 +194,7 @@ RSpec.describe do
       expect(expected[0].id).to eq(12334634)
       expect(expected.last.id).to eq(12334159)
     end
-  end
 
-  xdescribe 'iteration 4 functionality' do
-    sales_engine = SalesEngine.from_csv({
-                                        :items     => "./spec/fixtures/items_fixtures.csv",
-                                        :merchants => "./spec/fixtures/merchants_fixtures.csv",
-                                        :invoices => "./data/invoices.csv",
-                                        :invoice_items => "./data/invoice_items.csv",
-                                        :customers => "./data/customers.csv",
-                                        :transactions => "./data/transactions.csv"
-                                        })
-    sales_analyst = sales_engine.analyst
 
     it 'populates total revenue by date' do
       expect(sales_analyst.total_revenue_by_date(Time.parse("2009-02-07"))).to eq(21067.77)
@@ -214,21 +203,9 @@ RSpec.describe do
 
     it '#merchants_with_pending_invoices returns those merchants' do
 
-      expect(sales_analyst.merchants_with_pending_invoices.length).to eq(39)
+      expect(sales_analyst.merchants_with_pending_invoices.length).to eq(467)
       expect(sales_analyst.merchants_with_pending_invoices[0].class).to eq(Merchant)
     end
-  end
-
-  describe 'alex describe block yo' do
-    sales_engine = SalesEngine.from_csv({
-                                        :items     => "./data/items.csv",
-                                        :merchants => "./data/merchants.csv",
-                                        :invoices => "./data/invoices.csv",
-                                        :invoice_items => "./data/invoice_items.csv",
-                                        :transactions => "./data/transactions.csv",
-                                        :customers => "./data/customers.csv"
-                                        })
-    sales_analyst = sales_engine.analyst
 
     it "#merchants_with_only_one_item returns merchants with only one item" do
       expected = sales_analyst.merchants_with_only_one_item
@@ -244,5 +221,5 @@ RSpec.describe do
       expect(march_expected.length).to eq 21
       expect(expected.length).to eq 18
     end
-  end #keep this for Alex please and thank you
-end
+  end
+end #keep this for Alex please and thank you


### PR DESCRIPTION
This PR implements the `merchants_with_only_one_item_registered_in_month` method refactor as well as cleaning up the sales analyst test suite (we saved 69,286 objects from being created during each test).